### PR TITLE
Add call to sitespeed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Ignore tmp directory
+tmp/

--- a/src/__mocks__/callSitespeed.js
+++ b/src/__mocks__/callSitespeed.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const callSitespeed = async function(url) {
+  return { errors: [], budgetResult: { working: {}, failing: {} } }
+};
+
+module.exports = callSitespeed;

--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const server = require('../index')
+
+jest.mock('../callSitespeed')
+
+beforeAll((done) => {
+  server.events.on('start', () => {
+      done();
+  });
+});
+
+afterAll((done) => {
+  server.events.on('stop', () => {
+      done();
+  });
+  server.stop();
+});
+
+test('GET request returns failure', async () => {
+  const options = {
+    method: 'GET',
+    url: '/'
+  };
+  const data = await server.inject(options);
+  expect(data.statusCode).toBe(404);
+});
+
+test('POST request with no payload returns failure', async () => {
+  const options = {
+    method: 'POST',
+    url: '/',
+    payload: {
+      url: null
+    }
+  };
+  const data = await server.inject(options);
+  expect(data.statusCode).toBe(400);
+  expect(data.payload).toBe('Bad Request: no URL received');
+});
+
+test('POST request with incorrect URL returns failure', async () => {
+  const options = {
+    method: 'POST',
+    url: '/',
+    payload: {
+      url: 'badurl'
+    }
+  };
+  const data = await server.inject(options);
+  expect(data.statusCode).toBe(400);
+  expect(data.payload).toBe('Bad Request: bad URL received');
+});
+
+test('POST request with correct URL returns success', async () => {
+  const options = {
+    method: 'POST',
+    url: '/',
+    payload: {
+      url: 'http://example.com'
+    }
+  };
+
+  const data = await server.inject(options);
+  expect(data.statusCode).toBe(204);
+  expect(data.payload).toBe('');
+});

--- a/src/callSitespeed.js
+++ b/src/callSitespeed.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const sitespeed = require('sitespeed.io')
+
+const callSitespeed = async function(url) {
+  const urls = [url];
+  const name = new URL(urls[0]).host;
+  const timestamp = Date.now();
+
+  return await (async function run(){
+    try {
+      const result = await sitespeed.run({
+        urls,
+        browsertime: {
+          iterations: 1,
+          connectivity: {
+            profile: 'native',
+            downstreamKbps: undefined,
+            upstreamKbps: undefined,
+            latency: undefined,
+            engine: 'external',
+          },
+          headless: true,
+          browser: 'firefox'
+        },
+        sustainable: {
+          enable: true,
+          pageViews: 100000,
+          useGreenWebHostingAPI: true
+        },
+        firstParty: true,
+        outputFolder: `tmp/${name}-${timestamp}`,
+        name: name
+      });
+      return result;
+    } catch (e) {
+      return e;
+    }
+  })();
+};
+
+module.exports = callSitespeed;

--- a/src/index.js
+++ b/src/index.js
@@ -1,57 +1,63 @@
+'use strict';
+
 const Hapi = require('@hapi/hapi');
 
-const init = async () => {
+const callSitespeed = require('./callSitespeed');
 
-  const server = Hapi.server({
-    port: process.env.PORT || 3000,
-    host: 'localhost'
-  });
+const server = Hapi.server({
+  port: process.env.PORT || 3000,
+  host: 'localhost'
+});
 
-  server.route({
-    method: 'POST',
-    path: '/',
-    handler: (request, h) => {
-      const payload = request.payload
+server.route({
+  method: 'POST',
+  path: '/',
+  handler: async (request, h) => {
+    const url = request.payload.url
 
-
-      if (!payload) {
-        const msg = 'no Pub/Sub message received';
-        console.error(`error: ${msg}`);
-        return h.response(`Bad Request: ${msg}`).code(400)
-      }
-
-      const pubSubMessage = payload.message;
-
-      const name = pubSubMessage.data
-        ? Buffer.from(pubSubMessage.data, 'base64')
-          .toString()
-          .trim()
-        : 'World';
-
-      console.log(`Hello ${name}!`);
-
-      return h.response('created').code(204)
-    },
-    options: {
-      auth: false,
-      // validate: {
-      // payload: {
-      //     url: TODO
-      // Insert your joi schema here
-      //  https://hapi.dev/family/joi/tester/
-      // Joi.string().uri({
-      //   scheme: [
-      //     'http',
-      //     'https'
-      //    ]
-      // })
-
-      // }
-      // }
+    if (!url) {
+      const msg = 'no URL received';
+      return h.response(`Bad Request: ${msg}`).code(400);
     }
 
-  });
+    if (isUrl(url)) {
+      const result = await callSitespeed(url);
+      if (result.errors && result.errors.length > 0) {
+        return h.response(result.errors).code(400);
+      } else {
+        return h.response('created').code(204);
+      }
+    } else {
+      const msg = 'bad URL received';
+      return h.response(`Bad Request: ${msg}`).code(400);
+    }
+  },
+  options: {
+    auth: false,
+    // validate: {
+    // payload: {
+    //     url: TODO
+    // Insert your joi schema here
+    //  https://hapi.dev/family/joi/tester/
+    // Joi.string().uri({
+    //   scheme: [
+    //     'http',
+    //     'https'
+    //    ]
+    // })
 
+    // }
+    // }
+  }
+
+});
+
+const isUrl = function(url) {
+  const regexp = /(http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/
+  return regexp.test(url);
+}
+
+const init = async () => {
   await server.start();
   console.log('Server running on %s', server.info.uri);
 };
@@ -64,3 +70,5 @@ process.on('unhandledRejection', (err) => {
 });
 
 init();
+
+module.exports = server;


### PR DESCRIPTION
This is a PR for issue #1 .

I have written a function to call sitespeed.io and return either the results or the errors.

I have also updated the index.js route handler to confirm a URL was provided, and to asynchronously return either the errors or a success message from the call to sitespeed.

There is also a small (and long running) test on the callSitespeed function, but this can probably be improved upon.

Currently, this is writing the responses of the sitespeed call to the tmp directory. This can be changed, or we can write something to ship the data to another location.