### PR TITLE
Use the same slim firefox basis for a docker container as sitespeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ENV FIREFOX_VERSION 74.0
 
 ENV PATH="/usr/local/bin:${PATH}"
 
+RUN apt-get update && apt -y install vim
+
 RUN buildDeps='wget bzip2' && apt-get update && apt -y install $buildDeps && \
     # Download and unpack the correct Firefox version
     wget https://ftp.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 && \
@@ -31,7 +33,20 @@ RUN buildDeps='wget bzip2' && apt-get update && apt -y install $buildDeps && \
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . /usr/src/app
-RUN npm install
+RUN CHROMEDRIVER_SKIP_DOWNLOAD=true EGDEDRIVER_SKIP_DOWNLOAD=true npm install --production
 
-ENTRYPOINT ["npm","start"]
+WORKDIR /usr/src/app
+COPY docker/scripts/start-slim.sh /start.sh
+
+# Allow all users to run commands needed by sitespeedio/throttle via sudo
+# See https://github.com/sitespeedio/throttle/blob/master/lib/tc.js
+RUN echo 'ALL ALL=NOPASSWD: /usr/sbin/tc, /usr/sbin/route, /usr/sbin/ip' > /etc/sudoers.d/tc
+
+
+
+# ENTRYPOINT ["npm","start"]
+ENTRYPOINT ["bash","/start.sh"]
+
+VOLUME /sitespeed.io
+WORKDIR /sitespeed.io
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,37 @@
-# Use the sitespeed image
-FROM sitespeedio/sitespeed.io:11.9.3-plus1
+FROM node:12.16.1-buster-slim
 
-# Create and change to the app directory.
+ENV SITESPEED_IO_BROWSERTIME__DOCKER true
+ENV SITESPEED_IO_BROWSERTIME__VIDEO false
+ENV SITESPEED_IO_BROWSERTIME__BROWSER firefox
+ENV SITESPEED_IO_BROWSERTIME__VISUAL_METRICS false
+ENV SITESPEED_IO_BROWSERTIME__HEADLESS true
+ENV CHROMEDRIVER_SKIP_DOWNLOAD true
+ENV EGDEDRIVER_SKIP_DOWNLOAD true
+
+ENV FIREFOX_VERSION 74.0
+
+ENV PATH="/usr/local/bin:${PATH}"
+
+RUN buildDeps='wget bzip2' && apt-get update && apt -y install $buildDeps && \
+    # Download and unpack the correct Firefox version
+    wget https://ftp.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.bz2 && \
+    tar -xjf firefox-${FIREFOX_VERSION}.tar.bz2 && \
+    rm firefox-${FIREFOX_VERSION}.tar.bz2 && \
+    mv firefox /opt/ && \
+    ln -s /opt/firefox/firefox /usr/local/bin/firefox && \
+    # Install dependencies for Firefox
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        `apt-cache depends firefox-esr | awk '/Depends:/{print$2}'` && \
+    # iproute2 = tc
+    apt -y install tcpdump iproute2 ca-certificates sudo --no-install-recommends --no-install-suggests && \
+    # Cleanup
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $toolDeps \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
+RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
+COPY . /usr/src/app
+RUN npm install
 
-# Copy application dependency manifests to the container image.
-# A wildcard is used to ensure both package.json AND package-lock.json are copied.
-# Copying this separately prevents re-running npm install on every code change.
-COPY package*.json ./
+ENTRYPOINT ["npm","start"]
 
-# Install dependencies.
-# If you add a package-lock.json speed your build by switching to 'npm ci'.
-# RUN npm ci --only=production
-RUN npm install --production
-
-# Copy local code to the container image.
-COPY . .
-
-# Run the web service on container startup.
-CMD [ "npm", "start" ]

--- a/bin/greenspeed.js
+++ b/bin/greenspeed.js
@@ -21,15 +21,10 @@ const definition = {
       alias: 'url',
   },
   s: {
-    description: 'Run greenspeed as a server, designed to allow triggering of runs though a browser',
+    description: 'Run greenspeed as an API, triggering runs via POST request',
     alias: 'server',
     type: 'boolean'
   },
-  a: {
-    description: 'Runs as an API server, as part of a larger system',
-    alias: 'headless',
-    type: 'boolean'
-  }
 
 };
 

--- a/bin/greenspeed.js
+++ b/bin/greenspeed.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+/*eslint no-console: 0*/
+
+'use strict';
+
+const log = require("debug")("gd:greenspeed:cli");
+const callSiteSpeed = require("../src/callSitespeed");
+const Bossy = require('@hapi/bossy');
+
+const { start } = require("../src/index");
+
+const definition = {
+  h: {
+      description: 'Show help',
+      alias: 'help',
+      type: 'boolean'
+  },
+  u: {
+      description: 'The url of the page you want to check',
+      alias: 'url',
+  },
+  s: {
+    description: 'Run greenspeed as a server, designed to allow triggering of runs though a browser',
+    alias: 'server',
+    type: 'boolean'
+  },
+  a: {
+    description: 'Runs as an API server, as part of a larger system',
+    alias: 'headless',
+    type: 'boolean'
+  }
+
+};
+
+const args = Bossy.parse(definition);
+
+if (args instanceof Error) {
+    console.error(args.message);
+    return;
+}
+if (args.h) {
+    console.log(Bossy.usage(definition, 'greenspeed -u <url>'));
+    return;
+}
+
+
+let showUsage = true;
+
+for (let val of Object.values(args)) {
+  if (val) {
+    showUsage = false;
+  }
+}
+
+if (showUsage) {
+  console.log(Bossy.usage(definition, 'greenspeed -u <url>'))
+  return
+}
+
+if (args._) {
+  if (args._.length) {
+    args.u = args._[0];
+  args.url = args._[0];
+  }
+}
+
+async function runGreenSpeedCLI(args) {
+  // pull out domain
+  log(`Running greenspeed with ${args}`)
+  process.exitCode = 1;
+  try {
+    const result = await callSiteSpeed(args.url);
+    log("WORKED")
+    process.exitCode = 0
+
+  } catch (e) {
+    log("FAILED", e)
+    process.exitCode = 1;
+  } finally {
+    process.exit();
+  }
+}
+
+async function runServer(args) {
+  start();
+}
+
+async function main(args) {
+
+  if (args.u) {
+    return await runGreenSpeedCLI(args)
+  }
+  if (args.s) {
+    return await runServer(args)
+  }
+}
+main(args);

--- a/docker/scripts/start-slim.sh
+++ b/docker/scripts/start-slim.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+firefox --version
+
+SITESPEEDIO=/usr/src/app/bin/check-domain.js
+SITESPEEDIO_SERVER=/usr/src/app/src/index.js
+
+MAX_OLD_SPACE_SIZE="${MAX_OLD_SPACE_SIZE:-2048}"
+
+WORKDIR_UID=$(stat -c "%u" .)
+WORKDIR_GID=$(stat -c "%g" .)
+
+# Create user with the same UID and GID as the owner of the working directory, which will be used
+# to execute node. This is partly for security and partly so output files won't be owned by root.
+groupadd --non-unique --gid $WORKDIR_GID sitespeedio
+useradd --non-unique --uid $WORKDIR_UID --gid $WORKDIR_GID --home-dir /tmp sitespeedio
+
+# Need to explictly override the HOME directory to prevent dconf errors like:
+# (firefox:2003): dconf-CRITICAL **: 00:31:23.379: unable to create directory '/root/.cache/dconf': Permission denied.  dconf will not work properly.
+export HOME=/tmp
+
+
+# Inspired by docker-selenium way of shutting down
+function shutdown {
+  kill -s SIGTERM ${PID}
+  wait $PID
+}
+
+chroot --skip-chdir --userspec='sitespeedio:sitespeedio' / node --max-old-space-size=$MAX_OLD_SPACE_SIZE $SITESPEEDIO_SERVER &
+
+PID=$!
+
+trap shutdown SIGTERM SIGINT
+wait $PID
+
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -310,6 +310,16 @@
         "@hapi/hoek": "9.x.x"
       }
     },
+    "@hapi/bossy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bossy/-/bossy-5.0.0.tgz",
+      "integrity": "sha512-/P89CNhRos1/rcytf19erNvnGsGDWuC7UxBRfoKIqkKHthnG9qRIRZCc5gmc7i/yp5ettKWqiYSf65HKDPz2bg==",
+      "requires": {
+        "@hapi/boom": "9.x.x",
+        "@hapi/hoek": "9.x.x",
+        "@hapi/joi": "17.x.x"
+      }
+    },
     "@hapi/bounce": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6016,17 +6016,17 @@
       "dev": true
     },
     "sitespeed.io": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/sitespeed.io/-/sitespeed.io-12.2.2.tgz",
-      "integrity": "sha512-8z5ZOqGl7cq0eeP+FNsqqJY/KSfVjOZ81Sm0h/dM2NS3LvTty/DTL6J9IVmDl5kyiwKW3YW4jLPBoy+aGLsClw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/sitespeed.io/-/sitespeed.io-12.3.1.tgz",
+      "integrity": "sha512-QEKb74SPWZe8TSrUScR0P7t0dlVxY8287yP32bu1AI9RuN3qIlP0xiYSqzgjyB6Df/75fay9FIRMppZfvR+iPg==",
       "requires": {
         "@google-cloud/storage": "3.2.0",
         "@tgwf/co2": "0.6.1",
         "aws-sdk": "2.613.0",
         "axe-core": "3.5.1",
-        "browsertime": "8.2.0",
+        "browsertime": "8.3.1",
         "cli-color": "1.4.0",
-        "coach-core": "5.0.0",
+        "coach-core": "5.0.1",
         "concurrent-queue": "7.0.2",
         "dayjs": "1.8.20",
         "fast-crc32c": "2.0.0",
@@ -6116,18 +6116,18 @@
           "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
         },
         "@babel/runtime": {
-          "version": "7.8.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-          "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+          "version": "7.9.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
+          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
           "optional": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
           },
           "dependencies": {
             "regenerator-runtime": {
-              "version": "0.13.4",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-              "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+              "version": "0.13.5",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+              "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
               "optional": true
             }
           }
@@ -6302,32 +6302,32 @@
           }
         },
         "@jimp/bmp": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.5.tgz",
-          "integrity": "sha512-2cYdgXaNykuPe9sjm11Jihp5VomyWTWziIuDDB7xnxQtEz2HUR0bjXm2MJJOfU0TL52H+LS2JIKtAxcLPzp28w==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.9.6.tgz",
+          "integrity": "sha512-T2Fh/k/eN6cDyOx0KQ4y56FMLo8+mKNhBh7GXMQXLK2NNZ0ckpFo3VHDBZ3HnaFeVTZXF/atLiR9CfnXH+rLxA==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "bmp-js": "^0.1.0",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/core": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.9.5.tgz",
-          "integrity": "sha512-P1mlB9UOeI3IAQ4lGTmRBGw+F/mHWXd3tSyBskjL4E3YJ1eNK7WRrErUj/vUOvSBIryotu7nGo8vv8Q8JZ7/8w==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.9.6.tgz",
+          "integrity": "sha512-sQO04S+HZNid68a9ehb4BC2lmW6iZ5JgU9tC+thC2Lhix+N/XKDJcBJ6HevbLgeTzuIAw24C5EKuUeO3C+rE5w==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "any-base": "^1.1.0",
             "buffer": "^5.2.0",
             "core-js": "^3.4.1",
             "exif-parser": "^0.1.12",
             "file-type": "^9.0.0",
             "load-bmfont": "^1.3.1",
-            "mkdirp": "0.5.1",
+            "mkdirp": "^0.5.1",
             "phin": "^2.9.1",
             "pixelmatch": "^4.0.2",
             "tinycolor2": "^1.4.1"
@@ -6352,273 +6352,273 @@
           }
         },
         "@jimp/custom": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.5.tgz",
-          "integrity": "sha512-FaR7M0oxqbd7ujBL5ryyllS+mEuMKbKaDsdb8Cpu9SAo80DBiasUrYFFD/45/aRa95aM5o8t4C4Pna2bx8t3Tg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.9.6.tgz",
+          "integrity": "sha512-ZYKgrBZVoQwvIGlQSO7MFmn7Jn8a9X5g1g+KOTDO9Q0s4vnxdPTtr/qUjG9QYX6zW/6AK4LaIsDinDrrKDnOag==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/core": "^0.9.5",
+            "@jimp/core": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/gif": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.5.tgz",
-          "integrity": "sha512-QxjLl15nIz/QTeNgLFUJIOMLIceMO2B/xLUWF1/WqaP7Su6SGasRS6JY8OZ9QnqJLMWkodoEJmL6DxwtoOtqdg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.9.6.tgz",
+          "integrity": "sha512-Z2muC2On8KHEVrWKCCM0L2eua9kw4bQETzT7gmVsizc8MXAKdS8AyVV9T3ZrImiI0o5UkAN/u0cPi1U2pSiD8Q==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1",
             "omggif": "^1.0.9"
           }
         },
         "@jimp/jpeg": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.5.tgz",
-          "integrity": "sha512-cBpXqmeegsLzf/mYk1WpYov2RH1W944re5P61/ag6AMWEMQ51BoBdgBy5JABZIELg2GQxpoG+g/KxUshRzeIAg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.9.6.tgz",
+          "integrity": "sha512-igSe0pIX3le/CKdvqW4vLXMxoFjTLjEaW6ZHt/h63OegaEa61TzJ2OM7j7DxrEHcMCMlkhUc9Bapk57MAefCTQ==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1",
             "jpeg-js": "^0.3.4"
           }
         },
         "@jimp/plugin-blit": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.5.tgz",
-          "integrity": "sha512-VmV99HeCPOyliY/uEGOaKO9EcqDxSBzKDGC7emNCLFzlbK4uty4/cYMKGKTBiZR9AS1rEd63LxrDtbHKR8CsqQ==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.9.6.tgz",
+          "integrity": "sha512-zp7X6uDU1lCu44RaSY88aAvsSKbgqUrfDyWRX1wsamJvvZpRnp1WekWlGyydRtnlUBAGIpiHCHmyh/TJ2I4RWA==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-blur": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.5.tgz",
-          "integrity": "sha512-FnAEhMW9ZK8D6qCLDeMAloi4h7TCch9ZWFdonj49gwllpvLksBpnL9PTft4dFXCwZgOAq2apYwW7cwTAIfAw4A==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.9.6.tgz",
+          "integrity": "sha512-xEi63hvzewUp7kzw+PI3f9CIrgZbphLI4TDDHWNYuS70RvhTuplbR6RMHD/zFhosrANCkJGr5OZJlrJnsCg6ug==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-color": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.5.tgz",
-          "integrity": "sha512-2aFE0tRdhAKCCgh+tFLsLPOSgrk3ttl2TtTP5FAXeKmzlLj7FZ/JKj0waaGWZKdJ+uDxsVpX3EhuK3CfukIyrg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.9.6.tgz",
+          "integrity": "sha512-o1HSoqBVUUAsWbqSXnpiHU0atKWy/Q1GUbZ3F5GWt/0OSDyl9RWM82V9axT2vePZHInKjIaimhnx1gGj8bfxkQ==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1",
             "tinycolor2": "^1.4.1"
           }
         },
         "@jimp/plugin-contain": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.5.tgz",
-          "integrity": "sha512-zhaCJnUqd8hhD8IXxbRALU6ZzCWWbQDulc8Tn8Hxnub0si7dlq/DxBQT7og6kCxswBj2zPBtRAHONEwLdt7Nfw==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.9.6.tgz",
+          "integrity": "sha512-Xz467EN1I104yranET4ff1ViVKMtwKLg1uRe8j3b5VOrjtiXpDbjirNZjP3HTlv8IEUreWNz4BK7ZtfHSptufA==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-cover": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.5.tgz",
-          "integrity": "sha512-rG7vtx7vV9mHCFR4YP9GzGEsaop0IkMidP3UFPULbDcBdEEkehEG7a0h2X4w/Nt07J3k8wVoXYTjrb/CXpWkaw==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.9.6.tgz",
+          "integrity": "sha512-Ocr27AvtvH4ZT/9EWZgT3+HQV9fG5njwh2CYMHbdpx09O62Asj6pZ4QI0kKzOcux1oLgv59l7a93pEfMOfkfwQ==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-crop": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.5.tgz",
-          "integrity": "sha512-yoScC43YhYlswTKyL4fmawGwF73HyuIRpp1R3mXa6qbMA9mjX9QiqNdAIMB3UMHeBcIgkOD/Zy1f90/skBMpxg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.9.6.tgz",
+          "integrity": "sha512-d9rNdmz3+eYLbSKcTyyp+b8Nmhf6HySnimDXlTej4UP6LDtkq2VAyVaJ12fz9x6dfd8qcXOBXMozSfNCcgpXYA==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-displace": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.5.tgz",
-          "integrity": "sha512-nwfB72qNP8kNyBnlaY0vgJys7RUjvI61Qp3AMMbKKaRSsthCx7aeKU9Cyv+AHMfcVkkt3NdTmh7ScE+hkNFUhA==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.9.6.tgz",
+          "integrity": "sha512-SWpbrxiHmUYBVWtDDMjaG3eRDBASrTPaad7l07t73/+kmU6owAKWQW6KtVs05MYSJgXz7Ggdr0fhEn9AYLH1Rg==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-dither": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.5.tgz",
-          "integrity": "sha512-Pp1ehm5Hon6LcttRG+d+x1UN1ww00P4cyBnMVRR3NMhIfgc0IjQgojik9ZXax3nVj7XkqXJJh8f5uxC1cvYUnA==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.9.6.tgz",
+          "integrity": "sha512-abm1GjfYK7ru/PoxH9fAUmhl+meHhGEClbVvjjMMe5g2S0BSTvMJl3SrkQD/FMkRLniaS/Qci6aQhIi+8rZmSw==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-flip": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.5.tgz",
-          "integrity": "sha512-rKbg8c9ePst3w2t1kxQt2H05/rUR5/pjjafhZ97s01pxH/SOJudy5d76nJGzRBYoaRnxpvDzpN+2+iA08wDY5Q==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.9.6.tgz",
+          "integrity": "sha512-KFZTzAzQQ5bct3ii7gysOhWrTKVdUOghkkoSzLi+14nO3uS/dxiu8fPeH1m683ligbdnuM/b22OuLwEwrboTHA==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-gaussian": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.5.tgz",
-          "integrity": "sha512-8HloHpVPgSsoWekslJ5uUPK2ddoLrGXQAVOyo3BT2pVgwbL317+r96NxPGKTxrY20fqex9SQrjx3kHeSWbysEA==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.9.6.tgz",
+          "integrity": "sha512-WXKLtJKWchXfWHT5HIOq1HkPKpbH7xBLWPgVRxw00NV/6I8v4xT63A7/Nag78m00JgjwwiE7eK2tLGDbbrPYig==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-invert": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.5.tgz",
-          "integrity": "sha512-tqfMqQqsU4ulaif0Kk/BydqmG5UbjT67dmMjwnDL7rke+ypJ8tzq7j9QeZ9SDFB+PxUQcy/kPEw/R2Ys7HHi8A==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.9.6.tgz",
+          "integrity": "sha512-Pab/cupZrYxeRp07N4L5a4C/3ksTN9k6Knm/o2G5C789OF0rYsGGLcnBR/6h69nPizRZHBYdXCEyXYgujlIFiw==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-mask": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.5.tgz",
-          "integrity": "sha512-lIOrKb/VT1laDIA1H1nPOdtOB4TVhMRlxanXoEP8uKdE6a2goqZHXbKLn9itkm0MxtsTlT9KIXwzGxjCV38B3w==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.9.6.tgz",
+          "integrity": "sha512-ikypRoDJkbxXlo6gW+EZOcTiLDIt0DrPwOFMt1bvL8UV2QPgX+GJ685IYwhIfEhBf/GSNFgB/NYsVvuSufTGeg==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-normalize": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.5.tgz",
-          "integrity": "sha512-gayxgPLDp2gynu2IacvdCtqw0bdcC2feUqYOBjTtCpAwIz1KP2Qd6qKjV1dAVGiLO9ESW5maMa0vIBiBkYOovg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.9.6.tgz",
+          "integrity": "sha512-V3GeuAJ1NeL7qsLoDjnypJq24RWDCwbXpKhtxB+Yg9zzgOCkmb041p7ysxbcpkuJsRpKLNABZeNCCqd83bRawA==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-print": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.5.tgz",
-          "integrity": "sha512-/BUSyCfvVhuFdf+rBdH1wbuY8r9J0qhn4Icy7HqO58By7I+V7q7jayoeiLk+zEBsAXpCUbWiZG3KWNtZhLWeQg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.9.6.tgz",
+          "integrity": "sha512-gKkqZZPQtMSufHOL0mtJm5d/KI2O6+0kUpOBVSYdGedtPXA61kmVnsOd3wwajIMlXA3E0bDxLXLdAguWqjjGgw==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1",
             "load-bmfont": "^1.4.0"
           }
         },
         "@jimp/plugin-resize": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.5.tgz",
-          "integrity": "sha512-vIMleLPbEv0qTE1Mnc7mg5HSFc4l4FxlbDniVUvpi8ZMFa8IkigcTeAgXUKacevNL7uZ66MrnpQ49J3tNE28dQ==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.9.6.tgz",
+          "integrity": "sha512-r5wJcVII7ZWMuY2l6WSbHPG6gKMFemtCHmJRXGUu+/ZhPGBz3IFluycBpHkWW3OB+jfvuyv1EGQWHU50N1l8Og==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-rotate": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.5.tgz",
-          "integrity": "sha512-BHlhwUruHNQkOpsfzTE2uuSfmkj5eiIDRSAC8whupUGGXNgS67tZJB6u0qDRIeSP/gWV5tGGwXQNMn3AahwR1Q==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.9.6.tgz",
+          "integrity": "sha512-B2nm/eO2nbvn1DgmnzMd79yt3V6kffhRNrKoo2VKcKFiVze1vGP3MD3fVyw5U1PeqwAFu7oTICFnCf9wKDWSqg==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugin-scale": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.5.tgz",
-          "integrity": "sha512-PDU8F77EPFTcLBVDcJtGUvPXA2acG4KqJMZauHwZLZxuiDEvt9qsDQm4aTKcN/ku8oWZjfGBSOamhx/QNUqV5Q==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.9.6.tgz",
+          "integrity": "sha512-DLsLB5S3mh9+TZY5ycwfLgOJvUcoS7bP0Mi3I8vE1J91qmA+TXoWFFgrIVgnEPw5jSKzNTt8WhykQ0x2lKXncw==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1"
           }
         },
         "@jimp/plugins": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.5.tgz",
-          "integrity": "sha512-3hvuXeRLj36ifpwE7I7g5Da9bKl/0y62t90ZN0hdQwhLBjRRF4u1e1JZpyu6EK98Bp+W/c8fJ2iuOsHadJOusg==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.9.6.tgz",
+          "integrity": "sha512-eQI29e+K+3L/fb5GbPgsBdoftvaYetSOO2RL5z+Gjk6R4EF4QFRo63YcFl+f72Kc1b0JTOoDxClvn/s5GMV0tg==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/plugin-blit": "^0.9.5",
-            "@jimp/plugin-blur": "^0.9.5",
-            "@jimp/plugin-color": "^0.9.5",
-            "@jimp/plugin-contain": "^0.9.5",
-            "@jimp/plugin-cover": "^0.9.5",
-            "@jimp/plugin-crop": "^0.9.5",
-            "@jimp/plugin-displace": "^0.9.5",
-            "@jimp/plugin-dither": "^0.9.5",
-            "@jimp/plugin-flip": "^0.9.5",
-            "@jimp/plugin-gaussian": "^0.9.5",
-            "@jimp/plugin-invert": "^0.9.5",
-            "@jimp/plugin-mask": "^0.9.5",
-            "@jimp/plugin-normalize": "^0.9.5",
-            "@jimp/plugin-print": "^0.9.5",
-            "@jimp/plugin-resize": "^0.9.5",
-            "@jimp/plugin-rotate": "^0.9.5",
-            "@jimp/plugin-scale": "^0.9.5",
+            "@jimp/plugin-blit": "^0.9.6",
+            "@jimp/plugin-blur": "^0.9.6",
+            "@jimp/plugin-color": "^0.9.6",
+            "@jimp/plugin-contain": "^0.9.6",
+            "@jimp/plugin-cover": "^0.9.6",
+            "@jimp/plugin-crop": "^0.9.6",
+            "@jimp/plugin-displace": "^0.9.6",
+            "@jimp/plugin-dither": "^0.9.6",
+            "@jimp/plugin-flip": "^0.9.6",
+            "@jimp/plugin-gaussian": "^0.9.6",
+            "@jimp/plugin-invert": "^0.9.6",
+            "@jimp/plugin-mask": "^0.9.6",
+            "@jimp/plugin-normalize": "^0.9.6",
+            "@jimp/plugin-print": "^0.9.6",
+            "@jimp/plugin-resize": "^0.9.6",
+            "@jimp/plugin-rotate": "^0.9.6",
+            "@jimp/plugin-scale": "^0.9.6",
             "core-js": "^3.4.1",
             "timm": "^1.6.1"
           }
         },
         "@jimp/png": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.9.5.tgz",
-          "integrity": "sha512-0GPq/XixXcuWIA3gpMCUUj6rhxT78Hu9oDC9reaHUCcC/5cRTd5Eh7wLafZL8EfOZWV3mh2FZtWiY1xaNHHlBQ==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.9.6.tgz",
+          "integrity": "sha512-9vhOG2xylcDqPbBf4lzpa2Sa1WNJrEZNGvPvWcM+XVhqYa8+DJBLYkoBlpI/qWIYA+eVWDnLF3ygtGj8CElICw==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/utils": "^0.9.5",
+            "@jimp/utils": "^0.9.6",
             "core-js": "^3.4.1",
             "pngjs": "^3.3.3"
           }
         },
         "@jimp/tiff": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.5.tgz",
-          "integrity": "sha512-EcRtiHsAQ9aygRRMWhGTVfitfHwllgt93GE1L8d/iwSlu3e3IIV38MDINdluQUQMU5jcFBcX6eyVVvsgCleGiQ==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.9.6.tgz",
+          "integrity": "sha512-pKKEMqPzX9ak8mek2iVVoW34+h/TSWUyI4NjbYWJMQ2WExfuvEJvLocy9Q9xi6HqRuJmUxgNIiC5iZM1PDEEfg==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
@@ -6627,25 +6627,25 @@
           }
         },
         "@jimp/types": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.9.5.tgz",
-          "integrity": "sha512-62inaxx8zy24WMP+bsg6ZmgsL49oyoGUIGcjDKzvyAY/O6opD+UMNlArhl0xvCCdzriQxbljtSv/8uyHxz4Xbw==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.9.6.tgz",
+          "integrity": "sha512-PSjdbLZ8d50En+Wf1XkWFfrXaf/GqyrxxgIwFWPbL+wrW4pmbYovfxSLCY61s8INsOFOft9dzzllhLBtg1aQ6A==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
-            "@jimp/bmp": "^0.9.5",
-            "@jimp/gif": "^0.9.5",
-            "@jimp/jpeg": "^0.9.5",
-            "@jimp/png": "^0.9.5",
-            "@jimp/tiff": "^0.9.5",
+            "@jimp/bmp": "^0.9.6",
+            "@jimp/gif": "^0.9.6",
+            "@jimp/jpeg": "^0.9.6",
+            "@jimp/png": "^0.9.6",
+            "@jimp/tiff": "^0.9.6",
             "core-js": "^3.4.1",
             "timm": "^1.6.1"
           }
         },
         "@jimp/utils": {
-          "version": "0.9.5",
-          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.5.tgz",
-          "integrity": "sha512-W9vse4/1AYmOjtIVACoBMdc/2te1zcPURhMYNEyiezCU7hWMdj/Z1mwiWFq3AYCgOG8GPVx0ZQzrgqUfUxfTHQ==",
+          "version": "0.9.6",
+          "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.9.6.tgz",
+          "integrity": "sha512-kzxcp0i4ecSdMXFEmtH+NYdBQysINEUTsrjm7v0zH8t/uwaEMOG46I16wo/iPBXJkUeNdL2rbXoGoxxoeSfrrA==",
           "optional": true,
           "requires": {
             "@babel/runtime": "^7.7.2",
@@ -7445,9 +7445,9 @@
           "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
         },
         "browsertime": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/browsertime/-/browsertime-8.2.0.tgz",
-          "integrity": "sha512-QNHihOH17R0pooFL+CBDBiFv+PsQW8xcHrp+UHooivjT1sYevAx8uWLReWcCgftZazPwYYdZZZ7pw1O/CWUqyg==",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/browsertime/-/browsertime-8.3.1.tgz",
+          "integrity": "sha512-s0EWHClX/OEvGR/58rIUvQX5QiD6X28LxndJwU2+xQs33vPcVbXWdXqqvpPTqqfGCie+Q3ilX7N/tam5ssJcLw==",
           "requires": {
             "@cypress/xvfb": "1.2.4",
             "@sitespeed.io/chromedriver": "80.0.3987-16d",
@@ -7473,7 +7473,7 @@
             "lodash.merge": "4.6.2",
             "lodash.pick": "4.4.0",
             "lodash.set": "4.3.2",
-            "selenium-webdriver": "4.0.0-alpha.5",
+            "selenium-webdriver": "4.0.0-alpha.7",
             "speedline-core": "1.4.2",
             "yargs": "15.1.0"
           },
@@ -7979,9 +7979,9 @@
           }
         },
         "coach-core": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/coach-core/-/coach-core-5.0.0.tgz",
-          "integrity": "sha512-4KezC40CxLUbDs6ouw4CgBvRKA0XlMjqR26k78G+G7I+9awqYd27y1C7dpPwsSyWemXPGlGuaaOuKBo2Ua6X8w==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/coach-core/-/coach-core-5.0.1.tgz",
+          "integrity": "sha512-/mHawzW870jmfQX2pd+5pG7eRps648IUlutPjjRVSUS8NNUDAB3p6Pmq5VW/T0TDKDUOIbgCxpWgItRF6TuRWQ==",
           "requires": {
             "filter-files": "0.4.0",
             "json-stable-stringify": "1.0.1",
@@ -10345,9 +10345,9 @@
           },
           "dependencies": {
             "regenerator-runtime": {
-              "version": "0.13.3",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-              "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+              "version": "0.13.5",
+              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+              "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
               "optional": true
             }
           }
@@ -11166,9 +11166,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
           "version": "2.9.0",
@@ -11760,13 +11760,6 @@
           "integrity": "sha512-Xm0aY5IjkcwGqLRSkAiSb28uPJ/gxXJncvJcc5Piy27Bf9Ds2iwgtUXjSKiLrRARvYbtMS1C4nkYGQYxNDbbiw==",
           "requires": {
             "minimist": "1.2.0"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            }
           }
         },
         "pako": {
@@ -12736,14 +12729,13 @@
           }
         },
         "selenium-webdriver": {
-          "version": "4.0.0-alpha.5",
-          "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.5.tgz",
-          "integrity": "sha512-hktl3DSrhzM59yLhWzDGHIX9o56DvA+cVK7Dw6FcJR6qQ4CGzkaHeXQPcdrslkWMTeq0Ci9AmCxq0EMOvm2Rkg==",
+          "version": "4.0.0-alpha.7",
+          "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.7.tgz",
+          "integrity": "sha512-D4qnTsyTr91jT8f7MfN+OwY0IlU5+5FmlO5xlgRUV6hDEV8JyYx2NerdTEqDDkNq7RZDYc4VoPALk8l578RBHw==",
           "requires": {
-            "jszip": "^3.1.5",
-            "rimraf": "^2.6.3",
-            "tmp": "0.0.30",
-            "xml2js": "^0.4.19"
+            "jszip": "^3.2.2",
+            "rimraf": "^2.7.1",
+            "tmp": "0.0.30"
           },
           "dependencies": {
             "rimraf": {
@@ -12753,20 +12745,6 @@
               "requires": {
                 "glob": "^7.1.3"
               }
-            },
-            "xml2js": {
-              "version": "0.4.23",
-              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-              "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-              "requires": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-              }
-            },
-            "xmlbuilder": {
-              "version": "11.0.1",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-              "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "greenspeed",
   "version": "0.0.1",
   "description": "A hosted version of sitespeed",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "jest",
     "start": "node src/index.js",
@@ -30,6 +30,7 @@
     "np": "^6.0.0"
   },
   "dependencies": {
+    "@hapi/bossy": "^5.0.0",
     "@hapi/hapi": "^19.0.0",
     "@tgwf/co2": "^0.6.0",
     "sitespeed.io": "^12.3.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "@hapi/hapi": "^19.0.0",
     "@tgwf/co2": "^0.6.0",
-    "sitespeed.io": "^12.0.0"
+    "sitespeed.io": "^12.3.1"
   }
 }

--- a/src/__test__/index.test.js
+++ b/src/__test__/index.test.js
@@ -1,67 +1,71 @@
 'use strict';
 
-const server = require('../index')
+const { init, start } = require('../index');
 
-jest.mock('../callSitespeed')
+jest.mock('../callSitespeed');
 
-beforeAll((done) => {
-  server.events.on('start', () => {
-      done();
+describe ("API Server", () => {
+
+  let server;
+
+  beforeEach(async () => {
+    server = await init();
   });
-});
-
-afterAll((done) => {
-  server.events.on('stop', () => {
-      done();
+  
+  afterEach(async () => {
+    await server.stop();
   });
-  server.stop();
-});
 
-test('GET request returns failure', async () => {
-  const options = {
-    method: 'GET',
-    url: '/'
-  };
-  const data = await server.inject(options);
-  expect(data.statusCode).toBe(404);
-});
+  test('GET request returns failure', async () => {
 
-test('POST request with no payload returns failure', async () => {
-  const options = {
-    method: 'POST',
-    url: '/',
-    payload: {
-      url: null
-    }
-  };
-  const data = await server.inject(options);
-  expect(data.statusCode).toBe(400);
-  expect(data.payload).toBe('Bad Request: no URL received');
-});
+    const options = {
+      method: 'GET',
+      url: '/'
+    };
+    const data = await server.inject(options);
+    expect(data.statusCode).toBe(404);
+  });
+  
+  test('POST request with no payload returns failure', async () => {
+    const options = {
+      method: 'POST',
+      url: '/',
+      payload: {
+        url: null
+      }
+    };
+    const data = await server.inject(options);
+    expect(data.statusCode).toBe(400);
+    expect(data.payload).toBe('Bad Request: no URL received');
+  });
+  
+  test('POST request with incorrect URL returns failure', async () => {
+    const options = {
+      method: 'POST',
+      url: '/',
+      payload: {
+        url: 'badurl'
+      }
+    };
+    const data = await server.inject(options);
+    expect(data.statusCode).toBe(400);
+    expect(data.payload).toBe('Bad Request: bad URL received');
+  });
+  
+  test('POST request with correct URL returns success', async () => {
+    const options = {
+      method: 'POST',
+      url: '/',
+      payload: {
+        url: 'http://example.com'
+      }
+    };
+  
+    const data = await server.inject(options);
+    expect(data.statusCode).toBe(204);
+    expect(data.payload).toBe('');
+  });
 
-test('POST request with incorrect URL returns failure', async () => {
-  const options = {
-    method: 'POST',
-    url: '/',
-    payload: {
-      url: 'badurl'
-    }
-  };
-  const data = await server.inject(options);
-  expect(data.statusCode).toBe(400);
-  expect(data.payload).toBe('Bad Request: bad URL received');
-});
+})
 
-test('POST request with correct URL returns success', async () => {
-  const options = {
-    method: 'POST',
-    url: '/',
-    payload: {
-      url: 'http://example.com'
-    }
-  };
 
-  const data = await server.inject(options);
-  expect(data.statusCode).toBe(204);
-  expect(data.payload).toBe('');
-});

--- a/src/callSitespeed.js
+++ b/src/callSitespeed.js
@@ -25,10 +25,11 @@ const callSitespeed = async function(url) {
         },
         sustainable: {
           enable: true,
-          pageViews: 100000,
-          useGreenWebHostingAPI: true
+          hosting: true,
+          co2PerDomain: true,
+          dirtiestResources: true,
+          useGreenWebHostingAPI: true,
         },
-        firstParty: true,
         outputFolder: `tmp/${name}-${timestamp}`,
         name: name
       });

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@
 const Hapi = require('@hapi/hapi');
 
 const callSitespeed = require('./callSitespeed');
+const log = require("debug")("gd:greenspeed:server");
 
 const server = Hapi.server({
   port: process.env.PORT || 3000,
@@ -34,20 +35,6 @@ server.route({
   },
   options: {
     auth: false,
-    // validate: {
-    // payload: {
-    //     url: TODO
-    // Insert your joi schema here
-    //  https://hapi.dev/family/joi/tester/
-    // Joi.string().uri({
-    //   scheme: [
-    //     'http',
-    //     'https'
-    //    ]
-    // })
-
-    // }
-    // }
   }
 
 });
@@ -57,18 +44,28 @@ const isUrl = function(url) {
   return regexp.test(url);
 }
 
-const init = async () => {
+const start = async () => {
   await server.start();
-  console.log('Server running on %s', server.info.uri);
+  log('Server running on %s', server.info.uri);
+  return server;
+};
+
+const init = async () => {
+  await server.initialize();
+  log('Server running on %s', server.info.uri);
+  return server;
 };
 
 
-process.on('unhandledRejection', (err) => {
 
+process.on('unhandledRejection', (err) => {
   console.log(err);
   process.exit(1);
 });
 
-init();
 
-module.exports = server;
+module.exports = {
+  start,
+  init,
+  server
+};

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const callSitespeed = require('./callSitespeed');
 
 const server = Hapi.server({
   port: process.env.PORT || 3000,
-  host: 'localhost'
+  host: '0.0.0.0'
 });
 
 server.route({

--- a/src/index.js
+++ b/src/index.js
@@ -46,13 +46,12 @@ const isUrl = function(url) {
 
 const start = async () => {
   await server.start();
-  log('Server running on %s', server.info.uri);
+  console.log('Server running on %s', server.info.uri);
   return server;
 };
 
 const init = async () => {
   await server.initialize();
-  log('Server running on %s', server.info.uri);
   return server;
 };
 


### PR DESCRIPTION
For reasons I can't understand, when I try using the same basis for a dockerfile as sitespeed, and use it as a library, calls we make to the browser using Geckodriver fail.

I've shared this docker container here to help see why this container works:

https://github.com/Greening-Digital/sitespeed.io/pull/1

But this one doesn't.
